### PR TITLE
Adopt default vpc nacl into terraform management

### DIFF
--- a/nacls-default.tf
+++ b/nacls-default.tf
@@ -1,0 +1,10 @@
+resource "aws_default_network_acl" "default" {
+  default_network_acl_id = aws_vpc.main.default_network_acl_id
+
+  # no rules defined, deny all traffic in this ACL
+
+  tags = merge(
+    { Name = "${var.vpc_name}-default" },
+    var.tags
+  )
+}


### PR DESCRIPTION
Each VPC created in AWS comes with a Default Network ACL that can be managed, but not destroyed.  This change will bring the NACL under management and remove all rules.